### PR TITLE
STOCK-11 csv 데이터를 context api에서 전역으로 관리

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,47 +1,41 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { BrowserRouter, Redirect, Switch } from 'react-router-dom';
 import { GlobalTheme } from 'remember-ui';
 
+import { StockProvider } from 'context/StockContext';
 import Routes from 'routers/routes';
 import CommonRoute from 'routers/CommonRoute';
 import NavBar from 'components/NavBar/NavBar';
 import Stock from 'pages/Stock/Stock';
 import Dashboard from 'pages/Dashboard/Dashboard';
 import Tag from 'pages/Tag/Tag';
-import { fetchStockListFromCsv } from 'services/stock';
 
 import { AppBody } from './App.styles';
 
 function App() {
   const { root, stock, tag } = Routes;
-  const [stockList, setStockList] = useState([]);
-
-  useEffect(() => {
-    (async () => {
-      const { data } = await fetchStockListFromCsv();
-      setStockList(data.slice(1).filter((el) => el.length > 1));
-    })();
-  }, []);
 
   return (
-    <BrowserRouter>
-      <AppBody>
-        <GlobalTheme />
-        <NavBar stockList={stockList} />
-        <Switch>
-          <CommonRoute path={stock.path}>
-            <Stock stockList={stockList} />
-          </CommonRoute>
-          <CommonRoute path={tag.path}>
-            <Tag stockList={stockList} />
-          </CommonRoute>
-          <CommonRoute path={root.path}>
-            <Dashboard stockList={stockList} />
-          </CommonRoute>
-          <Redirect to={root.path} />
-        </Switch>
-      </AppBody>
-    </BrowserRouter>
+    <StockProvider>
+      <BrowserRouter>
+        <AppBody>
+          <GlobalTheme />
+          <NavBar />
+          <Switch>
+            <CommonRoute path={stock.path}>
+              <Stock />
+            </CommonRoute>
+            <CommonRoute path={tag.path}>
+              <Tag />
+            </CommonRoute>
+            <CommonRoute path={root.path}>
+              <Dashboard />
+            </CommonRoute>
+            <Redirect to={root.path} />
+          </Switch>
+        </AppBody>
+      </BrowserRouter>
+    </StockProvider>
   );
 }
 

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -1,14 +1,19 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import Routes from 'routers/routes';
+import { StockContext } from 'context/StockContext';
 
 import { Container, StockList, StockItem, StockText } from './Navbar.styles';
 
-const NavBar = ({ stockList }) => {
+const NavBar = () => {
   const { pathname } = useLocation();
   const { stock, tag, root } = Routes;
   const [tagList, setTagList] = useState([]);
+
+  const {
+    state: { stockList },
+  } = useContext(StockContext);
 
   useEffect(() => {
     const tags = new Set([

--- a/src/context/StockContext.js
+++ b/src/context/StockContext.js
@@ -1,0 +1,78 @@
+import React, { useState, createContext, useEffect } from 'react';
+
+import { fetchStockListFromCsv, fetchStockDataFromCsv } from 'services/stock';
+
+const Context = createContext();
+
+const { Provider, Consumer: StockConsumer } = Context;
+let STOCK_DATA_LIST = {};
+
+const StockProvider = ({ children }) => {
+  const [stockList, setStockList] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await fetchStockListFromCsv();
+      setStockList(data.slice(1).filter((el) => el.length > 1));
+      STOCK_DATA_LIST = data
+        .slice(1)
+        .filter((el) => el.length > 1)
+        .reduce(
+          (acc, cur) => ({
+            ...acc,
+            [cur[0]]: {
+              code: cur[0],
+              name: cur[1],
+              nation: cur[2],
+              user_id: cur[3],
+              created_at: cur[4],
+              updated_at: cur[5],
+              tag_list: cur[6],
+              data: [],
+            },
+          }),
+          {}
+        );
+    })();
+  }, []);
+
+  const getStockData = async (stockCode) => {
+    if (!stockCode) return [];
+
+    if (
+      STOCK_DATA_LIST[stockCode]?.data &&
+      STOCK_DATA_LIST[stockCode]?.data.length > 0
+    ) {
+      return STOCK_DATA_LIST[stockCode].data;
+    }
+    const { data } = await fetchStockDataFromCsv(stockCode);
+
+    STOCK_DATA_LIST = {
+      ...STOCK_DATA_LIST,
+      [stockCode]: {
+        ...STOCK_DATA_LIST[stockCode],
+        data,
+      },
+    };
+
+    return data;
+  };
+
+  return (
+    <Provider
+      value={{
+        state: {
+          stockList,
+          STOCK_DATA_LIST,
+        },
+        actions: { getStockData },
+      }}
+    >
+      {children}
+    </Provider>
+  );
+};
+
+const StockContext = Context;
+
+export { StockProvider, StockConsumer, StockContext };

--- a/src/pages/Dashboard/Dashboard.js
+++ b/src/pages/Dashboard/Dashboard.js
@@ -1,18 +1,23 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import dayjs from 'dayjs';
 
 import { chartOption } from 'constants/chart';
 import { CalendarFormat } from 'constants/calendar';
 import { LOCALE } from 'constants/locale';
-import { fetchStockDataFromCsv } from 'services/stock';
 import StockChart from 'components/StockChart/StockChart';
 import StockCalendar from 'components/StockCalendar/StockCalendar';
 import { getTodayDate } from 'utils/day';
 import { getCurrency } from 'utils/chart';
+import { StockContext } from 'context/StockContext';
 
 import { Container } from './Dashboard.styles';
 
-const Dashboard = ({ stockList }) => {
+const Dashboard = () => {
+  const {
+    state: { stockList },
+    actions: { getStockData },
+  } = useContext(StockContext);
+
   const [isLoaded, setLoaded] = useState(false);
   const [option, setOption] = useState({
     ...chartOption,
@@ -43,11 +48,11 @@ const Dashboard = ({ stockList }) => {
     stockList
       .map((el) => el[0])
       .forEach(async (number) => {
-        fetchAllData.push(fetchStockDataFromCsv(number));
+        fetchAllData.push(getStockData(number));
       });
 
     Promise.all(fetchAllData).then((data) => {
-      data.forEach(({ data: stockAll }, index) => {
+      data.forEach((stockAll, index) => {
         const currentStock = stockList[index];
         const currency = (currentStock && currentStock[2]) || LOCALE.KO;
         const startDateIndex = stockAll.findIndex(
@@ -127,7 +132,7 @@ const Dashboard = ({ stockList }) => {
       setOptionUs(stockDataUs);
       setLoaded(true);
     });
-  }, [startDate, endDate, stockList]);
+  }, [startDate, endDate, stockList, getStockData]);
 
   return (
     <Container>

--- a/src/pages/Stock/Stock.js
+++ b/src/pages/Stock/Stock.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import { useRouteMatch } from 'react-router-dom';
 import { useHistory } from 'react-router';
 import dayjs from 'dayjs';
@@ -7,19 +7,22 @@ import Routes from 'routers/routes';
 import { chartOption } from 'constants/chart';
 import { CalendarFormat } from 'constants/calendar';
 import { LOCALE } from 'constants/locale';
-import { fetchStockDataFromCsv } from 'services/stock';
 import StockChart from 'components/StockChart/StockChart';
-// import StockTable from 'components/StockTable/StockTable';
 import StockCalendar from 'components/StockCalendar/StockCalendar';
 import { getTodayDate } from 'utils/day';
 import { getCurrency, getPercent } from 'utils/chart';
+import { StockContext } from 'context/StockContext';
 
 import { Container } from './Stock.styles';
 
-const Stock = ({ stockList }) => {
+const Stock = () => {
   const {
     params: { code: stockCode },
   } = useRouteMatch();
+  const {
+    state: { stockList },
+    actions: { getStockData },
+  } = useContext(StockContext);
 
   const history = useHistory();
   const { root } = Routes;
@@ -44,7 +47,7 @@ const Stock = ({ stockList }) => {
       const stockData = { ...chartOption };
       const stockDataPercent = { ...chartOption };
 
-      const { data: stockAll } = await fetchStockDataFromCsv(stockCode);
+      const stockAll = await getStockData(stockCode);
 
       const startDateIndex = stockAll.findIndex(
         (el) => el[0] === dayjs(startDate).format(CalendarFormat)
@@ -160,6 +163,7 @@ const Stock = ({ stockList }) => {
     getData();
   }, [
     endDate,
+    getStockData,
     history,
     percentTargetDate,
     root.path,

--- a/src/pages/Tag/Tag.js
+++ b/src/pages/Tag/Tag.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import { useRouteMatch } from 'react-router-dom';
 import { useHistory } from 'react-router';
 import dayjs from 'dayjs';
@@ -7,19 +7,23 @@ import Routes from 'routers/routes';
 import { chartOption } from 'constants/chart';
 import { CalendarFormat } from 'constants/calendar';
 import { LOCALE } from 'constants/locale';
-import { fetchStockDataFromCsv } from 'services/stock';
 import StockChart from 'components/StockChart/StockChart';
 import StockCalendar from 'components/StockCalendar/StockCalendar';
 import { getTodayDate } from 'utils/day';
 import { getCurrency, getPercent } from 'utils/chart';
 import { getStockListByTag } from 'utils/tag';
+import { StockContext } from 'context/StockContext';
 
 import { Container } from './Tag.styles';
 
-const Tag = ({ stockList }) => {
+const Tag = () => {
   const {
     params: { tag: tagName },
   } = useRouteMatch();
+  const {
+    state: { stockList },
+    actions: { getStockData },
+  } = useContext(StockContext);
 
   const history = useHistory();
   const { root } = Routes;
@@ -54,11 +58,11 @@ const Tag = ({ stockList }) => {
     _tagStockList
       .map((el) => el[0])
       .forEach(async (number) => {
-        fetchAllData.push(fetchStockDataFromCsv(number));
+        fetchAllData.push(getStockData(number));
       });
 
     Promise.all(fetchAllData).then((data) => {
-      data.forEach(({ data: stockAll }, index) => {
+      data.forEach((stockAll, index) => {
         const currentStock = _tagStockList[index];
         const currency = (currentStock && currentStock[2]) || LOCALE.KO;
         const startDateIndex = stockAll.findIndex(
@@ -153,6 +157,7 @@ const Tag = ({ stockList }) => {
     history,
     root.path,
     percentTargetDate,
+    getStockData,
   ]);
 
   const onChartClick = (params) => {


### PR DESCRIPTION
## 작업 내용 (Content)

- csv 데이터를 context api에서 전역으로 관리
- 전역 변수를 사용해서, 매번 새로운 종목에 대한 데이터를 불러올 때 마다 추가해두고(캐싱) 같은 요청이 있을 경우 로컬에 캐싱한 데이터를 사용.

## 링크 (Links)

- [Trello 카드 링크](https://trello.com/c/EIKBy8LJ)

## 기타 사항 (Etc)

- StockContext에 `let STOCK_DATA_LIST = {};`  이러한 전역변수를 만들어서 업데이트 하게 했는데, anti pattern인지??
- state로 관리 하려했는데, infinite loop 때문에 해결을 못함
